### PR TITLE
Add references to other communication channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This is not its documentation.
 
 ### Communication channels
 
-If you have any questions or feedback, you can use the following ways of
-reaching the Clangd community and developers:
+If you have any questions or feedback, you can reach community and developers
+through one of these channels:
 
-- #clangd room is hosted on [LLVM's Discord
+- quick chat #clangd room hosted on [LLVM's Discord
   channel](https://discord.gg/xS7Z362).
 - user questions and feature requests can be asked in Clangd topic on [LLVM
   Discussion Forums](https://llvm.discourse.group/c/llvm-project/clangd/34)
-- Clangd mailing list that is mainly used to discuss the development can be
-  joined at https://lists.llvm.org/cgi-bin/mailman/listinfo/clangd-dev.
+- for more detailed discussions
+  https://lists.llvm.org/cgi-bin/mailman/listinfo/clangd-dev.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ This is not its documentation.
 If you have any questions or feedback, you can reach community and developers
 through one of these channels:
 
-- quick chat #clangd room hosted on [LLVM's Discord
+- chat: #clangd room hosted on [LLVM's Discord
   channel](https://discord.gg/xS7Z362).
 - user questions and feature requests can be asked in Clangd topic on [LLVM
   Discussion Forums](https://llvm.discourse.group/c/llvm-project/clangd/34)
-- for more detailed discussions
-  https://lists.llvm.org/cgi-bin/mailman/listinfo/clangd-dev.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ This is not its documentation.
 - the **source code** is hosted at http://llvm.org/, and mirrored at
   https://github.com/llvm/llvm-project/tree/master/clang-tools-extra/clangd.
 - the **website source code** is at https://github.com/clangd/clangd.github.io/
+
+### Communication channels
+
+If you have any questions or feedback, you can use the following ways of
+reaching the Clangd community and developers:
+
+- #clangd room is hosted on [LLVM's Discord
+  channel](https://discord.gg/xS7Z362).
+- user questions and feature requests can be asked in Clangd topic on [LLVM
+  Discussion Forums](https://llvm.discourse.group/c/llvm-project/clangd/34)
+- Clangd mailing list that is mainly used to discuss the development can be
+  joined at https://lists.llvm.org/cgi-bin/mailman/listinfo/clangd-dev.


### PR DESCRIPTION
We already have some communication channels that can be used to help our
users, but they are not very discoverable. Adding several links to the
README might help us to reach more Clangd users.