### PR TITLE
Link against older, more-compatible versiosn of glibc symbols

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -62,7 +62,7 @@ jobs:
         - name: linux
           os: ubuntu-latest
           preinstall: sudo apt-get install ninja-build libz-dev
-          cflags: -O3 -gline-tables-only -DNDEBUG
+          cflags: -O3 -gline-tables-only -DNDEBUG -include $GITHUB_WORKSPACE/.github/workflows/lib_compat.h
           cmake: >
             "-DCMAKE_C_COMPILER=clang"
             "-DCMAKE_CXX_COMPILER=clang++"

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -43,32 +43,29 @@ jobs:
           os: windows-latest
           preinstall: choco install ninja
           vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          cflags: /O2 /DNDEBUG
           # FIXME: remove ALLOW_OLD_TOOLCHAIN once VS 16.5 is available.
           cmake: >
             "-DCMAKE_C_COMPILER=cl"
             "-DCMAKE_CXX_COMPILER=cl"
-            "-DCMAKE_CXX_FLAGS_RELEASE=/O2 /DNDEBUG"
-            "-DCMAKE_C_FLAGS_RELEASE=/O2 /DNDEBUG"
             "-DLLVM_ENABLE_ZLIB=OFF"
             "-DLLVM_USE_CRT_RELEASE=MT"
             "-DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON"
         - name: mac
           os: macos-latest
           preinstall: brew install ninja zlib p7zip
+          cflags: -O3 -gline-tables-only -DNDEBUG
           cmake: >
             "-DCMAKE_C_COMPILER=clang"
             "-DCMAKE_CXX_COMPILER=clang++"
-            "-DCMAKE_C_FLAGS_RELEASE=-O3 -gline-tables-only -DNDEBUG"
-            "-DCMAKE_CXX_FLAGS_RELEASE=-O3 -gline-tables-only -DNDEBUG"
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
         - name: linux
           os: ubuntu-latest
           preinstall: sudo apt-get install ninja-build libz-dev
+          cflags: -O3 -gline-tables-only -DNDEBUG
           cmake: >
             "-DCMAKE_C_COMPILER=clang"
             "-DCMAKE_CXX_COMPILER=clang++"
-            "-DCMAKE_CXX_FLAGS_RELEASE=-O3 -gline-tables-only -DNDEBUG"
-            "-DCMAKE_C_FLAGS_RELEASE=-O3 -gline-tables-only -DNDEBUG"
             "-DCMAKE_EXE_LINKER_FLAGS_RELEASE=-static-libgcc -Wl,--compress-debug-sections=zlib"
             "-DLLVM_STATIC_LINK_CXX_STDLIB=ON"
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
@@ -117,6 +114,8 @@ jobs:
         "-DCMAKE_BUILD_TYPE=Release"
         "-DCLANG_PLUGIN_SUPPORT=OFF"
         "-DLLVM_ENABLE_PLUGINS=OFF"
+        "-DCMAKE_C_FLAGS_RELEASE=${{ matrix.config.cflags }}"
+        "-DCMAKE_CXX_FLAGS_RELEASE=${{ matrix.config.cflags }}"
         ${{ matrix.config.cmake }}
     # LLVM 10 has no way to statically link zlib via CMake itself, AFAICT...
     - name: Statically link zlib

--- a/.github/workflows/lib_compat.h
+++ b/.github/workflows/lib_compat.h
@@ -1,0 +1,18 @@
+// This header forces the use of a particular version of glibc symbols.
+// This can make the resulting binary portable to systems with older glibcs.
+//
+// It must be included in each TU, with CFLAGS="-include glibc_compat.h" etc.
+//
+// We only list symbols known to be used. This is paired with a test enforcing
+// the max glibc symbol version. If the test fails, the list should be extended.
+// Find the old alternatives version to target with e.g.:
+//   objdump -T /lib/x86_64-linux-gnu/lib{c,m,pthread,rt}.so.* | grep "\bexpf\b"
+
+#define FORCE_SYMBOL_VERSION(sym, version) \
+  __asm__(".symver " #sym "," #sym "@" #version)
+
+FORCE_SYMBOL_VERSION(expf, GLIBC_2.2.5);
+FORCE_SYMBOL_VERSION(log, GLIBC_2.2.5);
+FORCE_SYMBOL_VERSION(pow, GLIBC_2.2.5);
+
+#undef FORCE_SYMBOL_VERSION


### PR DESCRIPTION
They're binary-compatible, the old versions are more widely available
and the new versions are more highly optimized. We prefer the former.