### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET flag.

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -55,6 +55,7 @@ jobs:
           os: macos-latest
           preinstall: brew install ninja zlib p7zip
           cflags: -O3 -gline-tables-only -DNDEBUG
+          env: MACOSX_DEPLOYMENT_TARGET=10.9
           cmake: >
             "-DCMAKE_C_COMPILER=clang"
             "-DCMAKE_CXX_COMPILER=clang++"


### PR DESCRIPTION
Set the flag to 10.9 (the same version of LLVM [official release](https://llvm.org/docs/ReleaseProcess.html#test-release-sh))

Make sure we support older version of macOS (10.9+) when building clangd with
the latest macOS (10.15).

Fixes #505 