### PR TITLE
Remove deprecated set-env command

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -86,15 +86,15 @@ jobs:
       run: |
         cmd /c "`"${{ matrix.config.vcvars }}`">NUL && set" | Foreach-Object {
           $name, $value = $_ -split '=', 2
-          if ($value) { echo "::set-env name=$($name)::$($value)" }
+          if ($value) { echo "$($name)=$($value)" >> $GITHUB_ENV }
         }
     - name: Fetch target commit
       uses: actions/download-artifact@v1
       with: { name: release }
     - name: Set target commit
       run: |
-        echo ::set-env name=LLVM_COMMIT::$(cat release/commit)
-        echo ::set-env name=CLANGD_DIR::clangd_${{ github.event.release.tag_name }}
+        echo "LLVM_COMMIT=$(cat release/commit)" >> $GITHUB_ENV
+        echo "CLANGD_DIR=clangd_${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       shell: bash
     - name: Clone LLVM
       uses: actions/checkout@v2

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -86,7 +86,9 @@ jobs:
       run: |
         cmd /c "`"${{ matrix.config.vcvars }}`">NUL && set" | Foreach-Object {
           $name, $value = $_ -split '=', 2
-          if ($value) { echo "$($name)=$($value)" >> $GITHUB_ENV }
+          if ($value) {
+            echo "$($name)=$($value)" >> $env:GITHUB_ENV
+          }
         }
     - name: Fetch target commit
       uses: actions/download-artifact@v1

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -31,8 +31,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Compute release info
       run: |
-        echo ::set-env name=RELEASE_COMMIT_SHORT::$(printf "%.12s" ${{ steps.pick.outputs.sha }})
-        echo ::set-env name=RELEASE_DATE::$(date -u +%Y%m%d)
+        echo "RELEASE_COMMIT_SHORT=$(printf \"%.12s\" ${{ steps.pick.outputs.sha }})" >> $GITHUB_ENV
+        echo "RELEASE_DATE=$(date -u +%Y%m%d)" >> $GITHUB_ENV
     - name: Create release
       uses: actions/create-release@master
       id: release


### PR DESCRIPTION
Environment files are to be used instead now:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/