### PR TITLE
Enable gRPC support for clangd on Linux

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -118,7 +118,7 @@ jobs:
         "-DCMAKE_BUILD_TYPE=Release"
         ${{ matrix.config.grpc_cmake }}
 
-        ninja -C ${{ env.GPC_BUILD_PATH }} install
+        ninja -C grpc-build install
     - name: Fetch target commit
       uses: actions/download-artifact@v1
       with: { name: release }

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -72,7 +72,8 @@ jobs:
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
             "-DCMAKE_PROJECT_INCLUDE=$GITHUB_WORKSPACE/.github/workflows/linux-static-deps.cmake"
             "-DCLANGD_ENABLE_REMOTE=ON"
-          # This is needed to avoid dynamic linking of additional libraries.
+          # Using c-ares as a module prevents dynamic linking of unneeded
+          # libraries. All other gRPC dependencies can be built from sources.
           grpc_cmake: >
             "-DgRPC_CARES_PROVIDER=package"
     steps:
@@ -104,19 +105,16 @@ jobs:
         path: grpc
         ref: v1.32.0
         submodules: recursive
-    - name: Prepare gRPC build environment
-      if: matrix.config.name == 'linux'
-      run: |
-        mkdir grpc-installation
-        mkdir grpc/build
-        echo "GRPC_INSTALL_PATH=$(realpath grpc-installation)" >> $GITHUB_ENV
-        echo "GRPC_BUILD_PATH=$(realpath grpc/build)" >> $GITHUB_ENV
     - name: Build gRPC
       if: matrix.config.name == 'linux'
       run: >
-        cmake -G Ninja -S grpc -B ${{ env.GRPC_BUILD_PATH }}
+        mkdir grpc-installation
+
+        mkdir grpc-build
+
+        cmake -G Ninja -S grpc -B grpc-build
         "-DgRPC_INSTALL=ON"
-        "-DCMAKE_INSTALL_PREFIX=${{ env.GRPC_INSTALL_PATH }}"
+        "-DCMAKE_INSTALL_PREFIX=grpc-installation"
         "-DCMAKE_BUILD_TYPE=Release"
         ${{ matrix.config.grpc_cmake }}
 
@@ -151,7 +149,7 @@ jobs:
         "-DLLVM_ENABLE_PLUGINS=OFF"
         "-DCMAKE_C_FLAGS_RELEASE=${{ matrix.config.cflags }}"
         "-DCMAKE_CXX_FLAGS_RELEASE=${{ matrix.config.cflags }}"
-        "-DGRPC_INSTALL_PATH=${{ env.GRPC_INSTALL_PATH }}"
+        "-DGRPC_INSTALL_PATH=grpc-installation"
         ${{ matrix.config.cmake }}
     - name: Ninja
       run: ninja -C ${{ env.CLANGD_DIR }} clangd

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -62,7 +62,7 @@ jobs:
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
         - name: linux
           os: ubuntu-latest
-          preinstall: sudo apt-get install ninja-build libz-dev
+          preinstall: sudo apt-get install ninja-build libz-dev libc-ares-dev
           cflags: -O3 -gline-tables-only -DNDEBUG -include $GITHUB_WORKSPACE/.github/workflows/lib_compat.h
           cmake: >
             "-DCMAKE_C_COMPILER=clang"
@@ -71,6 +71,10 @@ jobs:
             "-DLLVM_STATIC_LINK_CXX_STDLIB=ON"
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
             "-DCMAKE_PROJECT_INCLUDE=$GITHUB_WORKSPACE/.github/workflows/linux-static-deps.cmake"
+            "-DCLANGD_ENABLE_REMOTE=ON"
+          # This is needed to avoid dynamic linking of additional libraries.
+          grpc_cmake: >
+            "-DgRPC_CARES_PROVIDER=package"
     steps:
     - name: Clone scripts
       uses: actions/checkout@v2
@@ -90,6 +94,33 @@ jobs:
             echo "$($name)=$($value)" >> $env:GITHUB_ENV
           }
         }
+    # FIXME: gRPC support is currently available only on Linux. Other platforms
+    # will be added later.
+    - name: Clone gRPC
+      if: matrix.config.name == 'linux'
+      uses: actions/checkout@v2
+      with:
+        repository: grpc/grpc
+        path: grpc
+        ref: v1.32.0
+        submodules: recursive
+    - name: Prepare gRPC build environment
+      if: matrix.config.name == 'linux'
+      run: |
+        mkdir grpc-installation
+        mkdir grpc/build
+        echo "GRPC_INSTALL_PATH=$(realpath grpc-installation)" >> $GITHUB_ENV
+        echo "GRPC_BUILD_PATH=$(realpath grpc/build)" >> $GITHUB_ENV
+    - name: Build gRPC
+      if: matrix.config.name == 'linux'
+      run: >
+        cmake -G Ninja -S grpc -B ${{ env.GRPC_BUILD_PATH }}
+        "-DgRPC_INSTALL=ON"
+        "-DCMAKE_INSTALL_PREFIX=${{ env.GRPC_INSTALL_PATH }}"
+        "-DCMAKE_BUILD_TYPE=Release"
+        ${{ matrix.config.grpc_cmake }}
+
+        ninja -C ${{ env.GPC_BUILD_PATH }} install
     - name: Fetch target commit
       uses: actions/download-artifact@v1
       with: { name: release }
@@ -120,6 +151,7 @@ jobs:
         "-DLLVM_ENABLE_PLUGINS=OFF"
         "-DCMAKE_C_FLAGS_RELEASE=${{ matrix.config.cflags }}"
         "-DCMAKE_CXX_FLAGS_RELEASE=${{ matrix.config.cflags }}"
+        "-DGRPC_INSTALL_PATH=${{ env.GRPC_INSTALL_PATH }}"
         ${{ matrix.config.cmake }}
     - name: Ninja
       run: ninja -C ${{ env.CLANGD_DIR }} clangd


### PR DESCRIPTION
Start building clangd with remote index support on Linux.