### PR TITLE
Do not upload artifacts in autobuild job

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -129,11 +129,6 @@ jobs:
         ${{ env.CLANGD_DIR }}/LICENSE.TXT
         ${{ env.CLANGD_DIR }}/bin/clangd*
         ${{ env.CLANGD_DIR }}/lib/clang
-    - name: Upload artifact
-      uses: actions/upload-artifact@v1
-      with:
-        name: ${{ matrix.config.name }}
-        path: clangd.zip
     - name: Upload asset
       uses: actions/upload-release-asset@v1.0.1
       env: { GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}" }


### PR DESCRIPTION
Artifacts are used to pass data from one job to another but we upload
release assets in the same job we build them, hence artifacts are
redundant.