### PR TITLE
Remove obsolete compiler hack from windows build config.

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -44,13 +44,11 @@ jobs:
           preinstall: choco install ninja nasm
           vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           cflags: /O2 /DNDEBUG
-          # FIXME: remove ALLOW_OLD_TOOLCHAIN once VS 16.5 is available.
           cmake: >
             "-DCMAKE_C_COMPILER=cl"
             "-DCMAKE_CXX_COMPILER=cl"
             "-DLLVM_ENABLE_ZLIB=OFF"
             "-DLLVM_USE_CRT_RELEASE=MT"
-            "-DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON"
           grpc_cmake: >
             "-DgRPC_MSVC_STATIC_RUNTIME=ON"
           binary_extension: ".exe"


### PR DESCRIPTION
MSVC version is now 16.7+, see
https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md