### PR TITLE
Bump gRPC version to 1.33.2

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -104,7 +104,7 @@ jobs:
       with:
         repository: grpc/grpc
         path: grpc
-        ref: v1.32.0
+        ref: v1.33.2
         submodules: recursive
     - name: Build gRPC
       run: >

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -104,6 +104,9 @@ jobs:
       with:
         repository: grpc/grpc
         path: grpc
+        # We use the same version of gRPC for LLVM's clangd-ubuntu-tsan
+        # buildbot.
+        # https://github.com/llvm/llvm-zorg/blob/master/buildbot/google/docker/buildbot-clangd-ubuntu-clang/Dockerfile
         ref: v1.33.2
         submodules: recursive
     - name: Build gRPC


### PR DESCRIPTION
This is the same version we are using in our buildbot, so this will
surely be the "stable" version for us right now.