### PR TITLE
Include lib_compat.h while building gRPC

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -117,6 +117,8 @@ jobs:
         "-DgRPC_INSTALL=ON"
         "-DCMAKE_INSTALL_PREFIX=$HOME/grpc-installation"
         "-DCMAKE_BUILD_TYPE=Release"
+        "-DCMAKE_C_FLAGS_RELEASE=${{ matrix.config.cflags }}"
+        "-DCMAKE_CXX_FLAGS_RELEASE=${{ matrix.config.cflags }}"
         ${{ matrix.config.grpc_cmake }}
 
         ninja -C grpc-build install

--- a/.github/workflows/lib_compat.h
+++ b/.github/workflows/lib_compat.h
@@ -11,8 +11,10 @@
 #define FORCE_SYMBOL_VERSION(sym, version) \
   __asm__(".symver " #sym "," #sym "@" #version)
 
+FORCE_SYMBOL_VERSION(exp2, GLIBC_2.2.5);
 FORCE_SYMBOL_VERSION(expf, GLIBC_2.2.5);
 FORCE_SYMBOL_VERSION(log, GLIBC_2.2.5);
+FORCE_SYMBOL_VERSION(log2, GLIBC_2.2.5);
 FORCE_SYMBOL_VERSION(pow, GLIBC_2.2.5);
 
 #undef FORCE_SYMBOL_VERSION


### PR DESCRIPTION
While building clangd binaries we set required glibc version for symbols
to a minimum to cover systems with older glibc implementations. But we
were not doing that while building gRPC, which might depend on never
versions of these symbols.