### PR TITLE
Use ubuntu-18 for older glibc

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -62,7 +62,7 @@ jobs:
             "-DCMAKE_CXX_COMPILER=clang++"
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
         - name: linux
-          os: ubuntu-latest
+          os: ubuntu-18.04
           preinstall: sudo apt-get install ninja-build libz-dev libc-ares-dev
           cflags: -O3 -gline-tables-only -DNDEBUG -include $GITHUB_WORKSPACE/.github/workflows/lib_compat.h
           cmake: >-


### PR DESCRIPTION
There's pthread_cond_clockwait@GLIBC_2.30 introduced with new glibc,
which isn't available in older versions. To prevent such breakages we
are sticking to ubuntu-18 rather than moving to ubuntu-20.

For a sample error see
https://github.com/kadircet/clangd/runs/2011039246?check_suite_focus=true.

Version label grabbed from
https://github.com/actions/virtual-environments.