### PR TITLE
Allow using a different repository for the manual release

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -16,17 +16,28 @@ jobs:
         grep -m 1 -o "llvm-project@[[:xdigit:]]\{40,\}" << EOF | cut -f 2 -d@ > commit
         ${{ github.event.release.body }}
         EOF
+    - name: Find Repository
+      run: |
+        grep -m 1 -o "\w*/llvm-project@[[:xdigit:]]\{40,\}" << EOF | cut -f 1 -d@ > repo
+        echo "LLVM_COMMIT=$(cat release/commit)" >> $GITHUB_ENV
+        ${{ github.event.release.body }}
+        EOF
     - name: Mark as draft
       run: >
         curl --fail --show-error -XPATCH
         "-HAuthorization: Bearer ${{ secrets.RELEASE_TOKEN }}"
         "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}"
         "-d" '{"draft": true}'
-    - name: Persist release info
+    - name: Persist release info for commit
       uses: actions/upload-artifact@v1
       with:
         name: release
         path: commit
+    - name: Persist release info for repository
+      uses: actions/upload-artifact@v1
+      with:
+        name: release
+        path: repo
   # Build clangd using CMake/Ninja.
   #
   # This step is a template that runs on each OS, build config varies slightly.
@@ -126,12 +137,13 @@ jobs:
     - name: Set target commit
       run: |
         echo "LLVM_COMMIT=$(cat release/commit)" >> $GITHUB_ENV
+        echo "LLVM_REPO=$(cat release/commit)" >> $GITHUB_ENV
         echo "CLANGD_DIR=clangd_${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       shell: bash
     - name: Clone LLVM
       uses: actions/checkout@v2
       with:
-        repository: llvm/llvm-project
+        repository: ${{ env.LLVM_REPO }}
         path: llvm-project
         ref: ${{ env.LLVM_COMMIT }}
     - name: CMake

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: release
-        path: commit
+        path: commit.env
   # Build clangd using CMake/Ninja.
   #
   # This step is a template that runs on each OS, build config varies slightly.

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -137,7 +137,7 @@ jobs:
     - name: Set target commit
       run: |
         echo "LLVM_COMMIT=$(cat release/commit)" >> $GITHUB_ENV
-        echo "LLVM_REPO=$(cat release/commit)" >> $GITHUB_ENV
+        echo "LLVM_REPO=$(cat release/repo)" >> $GITHUB_ENV
         echo "CLANGD_DIR=clangd_${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       shell: bash
     - name: Clone LLVM

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -19,7 +19,6 @@ jobs:
     - name: Find Repository
       run: |
         grep -m 1 -o "\w*/llvm-project@[[:xdigit:]]\{40,\}" << EOF | cut -f 1 -d@ > repo
-        echo "LLVM_COMMIT=$(cat release/commit)" >> $GITHUB_ENV
         ${{ github.event.release.body }}
         EOF
     - name: Mark as draft

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Find LLVM commit
       run: |
-        perl -ne 'print "LLVM_REPO=$1\nLLVM_COMMIT=$2\n" if /(\w+)\/llvm-project@([[:xdigit:]]{4,})/' > commit.env <<EOF
+        perl -ne 'print "LLVM_REPO=$1\nLLVM_COMMIT=$2\n" if /(\w+\/llvm-project)@([[:xdigit:]]{40,})/' > commit.env <<EOF
         ${{ gthub.event.release.body }}
         EOF
     - name: Check LLVM commit was founud

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -13,30 +13,22 @@ jobs:
     steps:
     - name: Find LLVM commit
       run: |
-        grep -m 1 -o "llvm-project@[[:xdigit:]]\{40,\}" << EOF | cut -f 2 -d@ > commit
-        ${{ github.event.release.body }}
+        perl -ne 'print "LLVM_REPO=$1\nLLVM_COMMIT=$2\n" if /(\w+)\/llvm-project@([[:xdigit:]]{4,})/' > commit.env <<EOF
+        ${{ gthub.event.release.body }}
         EOF
-    - name: Find Repository
-      run: |
-        grep -m 1 -o "\w*/llvm-project@[[:xdigit:]]\{40,\}" << EOF | cut -f 1 -d@ > repo
-        ${{ github.event.release.body }}
-        EOF
+    - name: Check LLVM commit was founud
+      run: grep LLVM_REPO commit.env
     - name: Mark as draft
       run: >
         curl --fail --show-error -XPATCH
         "-HAuthorization: Bearer ${{ secrets.RELEASE_TOKEN }}"
         "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}"
         "-d" '{"draft": true}'
-    - name: Persist release info for commit
+    - name: Persist release info
       uses: actions/upload-artifact@v1
       with:
         name: release
         path: commit
-    - name: Persist release info for repository
-      uses: actions/upload-artifact@v1
-      with:
-        name: release
-        path: repo
   # Build clangd using CMake/Ninja.
   #
   # This step is a template that runs on each OS, build config varies slightly.
@@ -135,8 +127,7 @@ jobs:
       with: { name: release }
     - name: Set target commit
       run: |
-        echo "LLVM_COMMIT=$(cat release/commit)" >> $GITHUB_ENV
-        echo "LLVM_REPO=$(cat release/repo)" >> $GITHUB_ENV
+        cat release/commit.env >> $GITHUB_ENV
         echo "CLANGD_DIR=clangd_${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       shell: bash
     - name: Clone LLVM


### PR DESCRIPTION
Extract the repository from the commit message. This will help us have more control over the release process.