### PR TITLE
Rename clangd-indexing-tools-platform-version.zip -> clangd_indexing_tools-platform-version.zip

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -183,7 +183,7 @@ jobs:
       env: { GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}" }
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_name: clangd-indexing-tools-${{ matrix.config.name }}-${{ github.event.release.tag_name }}.zip
+        asset_name: clangd_indexing_tools-${{ matrix.config.name }}-${{ github.event.release.tag_name }}.zip
         asset_path: indexing-tools.zip
         asset_content_type: application/zip
     - name: Check binary compatibility


### PR DESCRIPTION
This allows autoupdate to work in our buggy clients.
See https://github.com/clangd/vscode-clangd/issues/180

Stylistic justification: "clangd_indexing_tools" is one "word" in the
"name-platform-version.zip" naming convention.