### PR TITLE
Bump gRPC version: 1.33.2 -> 1.36.3

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -105,7 +105,7 @@ jobs:
         # We use the same version of gRPC for LLVM's clangd-ubuntu-tsan
         # buildbot.
         # https://github.com/llvm/llvm-zorg/blob/master/buildbot/google/docker/buildbot-clangd-ubuntu-clang/Dockerfile
-        ref: v1.33.2
+        ref: v1.36.3
         submodules: recursive
     - name: Build gRPC
       run: >


### PR DESCRIPTION
Builds started to fail
(https://github.com/clangd/clangd/runs/2595990099?check_suite_focus=true)
because Abseil source file (built as a part of gRPC) was using
`std::numeric_limits` and `uint32_t` but not including `<limits>` and
`<cstdint>` directly
(https://github.com/abseil/abseil-cpp/blob/df3ea785d8c30a9503321a3d35ee7d35808f190d/absl/synchronization/internal/graphcycles.cc).

This worked with libstdc++ 10 but GitHub Actions recently updated the
toolchain for Ubuntu 18.04 LTS we're using
(https://github.com/actions/virtual-environments/commit/0409144182dc17ad9bed72886ba4aa3506cf8a6d#diff-8d528b68ca937dfe5a0194829f0eb2633bc3d7a3105a637ccb534a4da765f7a3R17).
libstdc++ 11 changed the standard headers and is now less forgiving when
it comes to `<limits>` and few other headers not being included directly
(https://gcc.gnu.org/gcc-11/porting_to.html#:~:text=%3Climits%3E%20%28for%20std%3A%3Anumeric_limits%29).

This patch increases the gRPC version we use to fix the CI. Another
viable solution is "downgrading" back to libstdc++10 (e.g. via `sudo
apt-get remove -y libgcc-11-dev`).

This also requires changes in
https://github.com/llvm/llvm-zorg/blob/master/buildbot/google/docker/buildbot-clangd-ubuntu-clang/Dockerfile
for consistency.

Related changes (required before landing this):

- [X] https://github.com/llvm/llvm-zorg/blob/master/buildbot/google/docker/buildbot-clangd-ubuntu-clang/Dockerfile
- [x] https://raw.githubusercontent.com/llvm/llvm-project/main/clang-tools-extra/clangd/index/remote/README.md
- [x] Revert #785