### PR TITLE
Allow keeping the workflow dispatch release as drafts

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -27,11 +27,14 @@ on:
       description:
         description: 'Release description'
         required: true
+      keep_as_draft:
+        description: 'Put "true" to avoid publishing the release'
+        required: false
 jobs:
   schedule_environment:
     name: Create default build environment
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'schedule' }}
+    if: github.event_name == 'schedule'
     steps:
     - name: Install deps
       run: |
@@ -75,7 +78,7 @@ jobs:
   workflow_dispatch_environment:
     name: Use inputs to create build environment
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: github.event_name == 'workflow_dispatch'
     steps:
     - name: Use repo and commit from the inputs
       run: |
@@ -318,7 +321,7 @@ jobs:
   finalize:
     runs-on: ubuntu-latest
     needs: build
-    if: always() && needs.build.result == 'success'
+    if: always() && needs.build.result == 'success' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.keep_as_draft == 'true')
     steps:
     - name: Fetch release info
       uses: actions/download-artifact@v1


### PR DESCRIPTION
This is useful for testing the release before publishing (something we
might need for newly released 13.0.0).

Also, clean up `${{}}` in `if`s, apparently they are not needed (even
though they are used throughout the documentation):

https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions