### PR TITLE
Link to GitHub Discussions when opening an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,4 +1,3 @@
-blank_issues_enabled: false
 contact_links:
    - name: Questions and discussions
      url: https://github.com/clangd/clangd/discussions

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+   - name: Questions and discussions
+     url: https://github.com/clangd/clangd/discussions
+     about: Usage questions, ideas and proposals


### PR DESCRIPTION
That will increase the visibility of the Discussions mechanism.

Also, make it impossible to open empty bug reports.