### PR TITLE
Fix windows snapshot builds

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -281,7 +281,8 @@ jobs:
         clangd-index-server-monitor
     - name: Install OpenMP headers
       run: >
-        cp ${{ env.CLANGD_DIR }}/projects/openmp/runtime/src/omp{,-tools}.h ${{ env.CLANGD_DIR }}/lib/clang/*/include
+        cp ${{ env.CLANGD_DIR }}/projects/openmp/runtime/src/omp.h ${{ env.CLANGD_DIR }}/lib/clang/*/include
+        cp ${{ env.CLANGD_DIR }}/projects/openmp/runtime/src/omp-tools.h ${{ env.CLANGD_DIR }}/lib/clang/*/include
     - name: Archive clangd
       run: >
         7z a clangd.zip


### PR DESCRIPTION
Powershell doesn't support brace expansions, so explicitly spell out omp.h and
omp-tools.h.

See https://github.com/clangd/clangd/runs/4755216973?check_suite_focus=true for
parse error.
