### PR TITLE
Use windows-2019 explicitly in CI

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -144,7 +144,7 @@ jobs:
       matrix:
         config:
         - name: windows
-          os: windows-latest
+          os: windows-2019
           preinstall: choco install ninja nasm
           vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           cflags: /O2 /DNDEBUG


### PR DESCRIPTION
windows-latest started pointing at windows-2022 image, which has different
software installed and causes failures in the pipeline.

Rather than updating the paths used in the CI, this PR just ensures we're using
the old image. As that's what we've been using to build all the unstable
releases so far and it might be risky to change it right before stable release.
I will rather have a cleanup after the clangd-14 release to use the new image.
