### PR TITLE
Modernize CI

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -116,14 +116,6 @@ jobs:
           ${{ env.RELEASE_DESCRIPTION }}
 
           Built from ${{ env.LLVM_REPO }}@${{ env.LLVM_COMMIT }}.
-    - name: Preserve release info
-      run: |
-        echo "TAG_NAME=${{ env.TAG_NAME }}" >> release.env
-    - name: Upload result
-      uses: actions/upload-artifact@v3
-      with:
-        name: release
-        path: release.env
   # Build clangd using CMake/Ninja.
   #
   # This step is a template that runs on each OS, build config varies slightly.
@@ -245,9 +237,7 @@ jobs:
       with:
         name: release
     - name: Put release info into env
-      run: |
-        cat commit.env >> $GITHUB_ENV
-        cat release.env >> $GITHUB_ENV
+      run: cat commit.env >> $GITHUB_ENV
       shell: bash
       # Use environment variables set above to create a directory. This needs
       # to be a separate step because they are not in the context yet when
@@ -325,12 +315,12 @@ jobs:
     needs: build
     if: always() && needs.build.result == 'success'
     steps:
-    - name: Fetch release info
+    - name: Fetch environment variables
       uses: actions/download-artifact@v3
       with:
-        name: release
-    - name: Update the env variables
-      run: cat release.env >> $GITHUB_ENV
+        name: env
+    - name: Set environment variables
+      run: cat commit.env >> $GITHUB_ENV
     - name: Setup gh
       uses: wusatosi/setup-gh@v1
       with:

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -307,24 +307,19 @@ jobs:
         ${{ env.CLANGD_DIR }}/bin/clangd-index-server${{ matrix.config.binary_extension }}
         ${{ env.CLANGD_DIR }}/bin/clangd-index-server-monitor${{ matrix.config.binary_extension }}
         ${{ env.CLANGD_DIR }}/lib/clang
-    - name: Upload clangd asset
+    - name: Upload clangd asset and indexing tools
       shell: bash
       run: |
-        mv clangd.zip ${{ env.RELEASE_FILE_NAME }} && 
+        mv clangd.zip ${{ env.RELEASE_FILE_NAME }}
         gh release upload ${{ env.TAG_NAME }} ${{ env.RELEASE_FILE_NAME }}
+        
+        mv indexing-tools.zip ${{ env.INDEXING_TOOL_NAME }}
+        gh release upload ${{ env.TAG_NAME }} ${{ env.INDEXING_TOOL_NAME }}
       env:
         GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         GH_REPO: ${{ github.repository }}
         RELEASE_FILE_NAME: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
-    - name: Upload indexing-tools asset
-      shell: bash
-      run: |
-        mv indexing-tools.zip ${{ env.RELEASE_FILE_NAME }} && 
-        gh release upload ${{ env.TAG_NAME }} ${{ env.RELEASE_FILE_NAME }}
-      env:
-        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        GH_REPO: ${{ github.repository }}
-        RELEASE_FILE_NAME: clangd_indexing_tools-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
+        INDEXING_TOOL_NAME: clangd_indexing_tools-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
     - name: Check binary compatibility
       if: matrix.config.name == 'linux'
       run: .github/workflows/lib_compat_test.py --lib=GLIBC_2.18 "$CLANGD_DIR/bin/clangd"

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -110,7 +110,6 @@ jobs:
         token: ${{ secrets.RELEASE_TOKEN }}
     - name: Create release
       run: gh release create ${{ env.TAG_NAME }} -t ${{ env.RELEASE_NAME }} -n ${{ env.body }} --draft --prerelease
-      id: create_release
       env:
         body: |
           ${{ env.RELEASE_DESCRIPTION }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -307,23 +307,23 @@ jobs:
         ${{ env.CLANGD_DIR }}/bin/clangd-index-server-monitor${{ matrix.config.binary_extension }}
         ${{ env.CLANGD_DIR }}/lib/clang
     - name: Upload clangd asset
-      uses: actions/upload-release-asset@v1.0.1
+      shell: bash
+      run: |
+        mv clangd.zip ${{ env.RELEASE_FILE_NAME }}
+        gh release upload ${{ env.TAG_NAME }} ${{ env.RELEASE_FILE_NAME }}
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      with:
-        upload_url: ${{ env.UPLOAD_URL }}
-        asset_name: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
-        asset_path: clangd.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        RELEASE_FILE_NAME: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
     - name: Upload indexing-tools asset
-      uses: actions/upload-release-asset@v1.0.1
+      shell: bash
+      run: |
+        mv indexing-tools.zip ${{ env.RELEASE_FILE_NAME }}
+        gh release upload ${{ env.TAG_NAME }} ${{ env.RELEASE_FILE_NAME }}
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-      with:
-        upload_url: ${{ env.UPLOAD_URL }}
-        asset_name: clangd_indexing_tools-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
-        asset_path: indexing-tools.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        RELEASE_FILE_NAME: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
     - name: Check binary compatibility
       if: matrix.config.name == 'linux'
       run: .github/workflows/lib_compat_test.py --lib=GLIBC_2.18 "$CLANGD_DIR/bin/clangd"

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -310,7 +310,7 @@ jobs:
     - name: Upload clangd asset
       shell: bash
       run: |
-        mv clangd.zip ${{ env.RELEASE_FILE_NAME }}
+        mv clangd.zip ${{ env.RELEASE_FILE_NAME }} && 
         gh release upload ${{ env.TAG_NAME }} ${{ env.RELEASE_FILE_NAME }}
       env:
         GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -319,7 +319,7 @@ jobs:
     - name: Upload indexing-tools asset
       shell: bash
       run: |
-        mv indexing-tools.zip ${{ env.RELEASE_FILE_NAME }}
+        mv indexing-tools.zip ${{ env.RELEASE_FILE_NAME }} && 
         gh release upload ${{ env.TAG_NAME }} ${{ env.RELEASE_FILE_NAME }}
       env:
         GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -110,6 +110,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       id: create_release
       with:
+        repository: ${{ github.repository }}
         tag_name: ${{ env.TAG_NAME }}
         name: ${{ env.RELEASE_NAME }}
         body: |

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -178,12 +178,6 @@ jobs:
             apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&
             apt-get update &&
             apt-get install -y git cmake
-
-            # Install github cli for uploading artifacts, this is only needed on linux CI because we use container for linux
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg &&
-            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg &&
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null &&
-            apt update  && apt install gh -y
           cflags: -O3 -gline-tables-only -DNDEBUG -include $GITHUB_WORKSPACE/.github/workflows/lib_compat.h
           cmake: >-
             "-DCMAKE_C_COMPILER=clang-9"
@@ -208,6 +202,10 @@ jobs:
     # Visual Studio tools require a bunch of environment variables to be set.
     # Run vcvars64.bat and re-export the current environment to the workflow.
     # (It'd be nice to only export the variables that *changed*, oh well).
+    - name: Setup gh
+      uses: wusatosi/setup-gh@main
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
     - name: Visual Studio environment
       if: matrix.config.name == 'windows'
       shell: powershell
@@ -321,8 +319,6 @@ jobs:
         mv indexing-tools.zip ${{ env.INDEXING_TOOL_NAME }}
         gh release upload ${{ env.TAG_NAME }} ${{ env.INDEXING_TOOL_NAME }}
       env:
-        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        GH_REPO: ${{ github.repository }}
         RELEASE_FILE_NAME: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
         INDEXING_TOOL_NAME: clangd_indexing_tools-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
     - name: Check binary compatibility

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -342,8 +342,7 @@ jobs:
       run: >
         cat release/release.env >> $GITHUB_ENV
     - name: Publish release
-      run: >
-        curl -XPATCH
-        "-HAuthorization: Bearer ${{ secrets.RELEASE_TOKEN }}"
-        "https://api.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}"
-        "-d" '{"draft": false}'
+      run: gh release edit ${{ env.TAG_NAME }} --draft=false
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GH_REPO: ${{ github.repository }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -170,15 +170,20 @@ jobs:
         - name: linux
           os: ubuntu-latest
           container: ubuntu:18.04
-          preinstall: >-
+          preinstall: |
             apt-get update &&
-            apt-get install -y ninja-build libz-dev libc-ares-dev wget clang-9
-            software-properties-common p7zip-full curl &&
+            apt-get install -y ninja-build libz-dev libc-ares-dev wget clang-9 software-properties-common p7zip-full curl &&
             add-apt-repository ppa:git-core/ppa &&
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - &&
             apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&
             apt-get update &&
             apt-get install -y git cmake
+
+            # Install github cli for uploading artifacts, this is only needed on linux CI because we use container for linux
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg &&
+            chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg &&
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null &&
+            apt update  && apt install gh -y
           cflags: -O3 -gline-tables-only -DNDEBUG -include $GITHUB_WORKSPACE/.github/workflows/lib_compat.h
           cmake: >-
             "-DCMAKE_C_COMPILER=clang-9"

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -107,13 +107,11 @@ jobs:
       run: |
         cat env/commit.env >> $GITHUB_ENV
     - name: Create release
-      uses: actions/create-release@master
+      uses: softprops/action-gh-release@v1
       id: create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ env.TAG_NAME }}
-        release_name: ${{ env.RELEASE_NAME }}
+        name: ${{ env.RELEASE_NAME }}
         body: |
           ${{ env.RELEASE_DESCRIPTION }}
 
@@ -122,7 +120,7 @@ jobs:
         draft: true
     - name: Preserve release info
       run: |
-        echo "UPLOAD_URL=${{ steps.create_release.outputs.upload_url }}" >> release.env
+        echo "UPLOAD_URL=${{ steps.create_release.outputs.url }}" >> release.env
         echo "TAG_NAME=${{ env.TAG_NAME }}" >> release.env
         echo "RELEASE_ID=${{ steps.create_release.outputs.id }}" >> release.env
     - name: Upload result

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -324,7 +324,7 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         GH_REPO: ${{ github.repository }}
-        RELEASE_FILE_NAME: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
+        RELEASE_FILE_NAME: clangd_indexing_tools-${{ matrix.config.name }}-${{ env.TAG_NAME }}.zip
     - name: Check binary compatibility
       if: matrix.config.name == 'linux'
       run: .github/workflows/lib_compat_test.py --lib=GLIBC_2.18 "$CLANGD_DIR/bin/clangd"

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -121,9 +121,7 @@ jobs:
         draft: true
     - name: Preserve release info
       run: |
-        echo "UPLOAD_URL=${{ steps.create_release.outputs.url }}" >> release.env
         echo "TAG_NAME=${{ env.TAG_NAME }}" >> release.env
-        echo "RELEASE_ID=${{ steps.create_release.outputs.id }}" >> release.env
     - name: Upload result
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -105,7 +105,7 @@ jobs:
           env
     - name: Set environment variables
       run: |
-        cat env/commit.env >> $GITHUB_ENV
+        cat commit.env >> $GITHUB_ENV
     - name: Create release
       uses: softprops/action-gh-release@v1
       id: create_release
@@ -247,8 +247,8 @@ jobs:
         name: release
     - name: Put release info into env
       run: |
-        cat env/commit.env >> $GITHUB_ENV
-        cat release/release.env >> $GITHUB_ENV
+        cat commit.env >> $GITHUB_ENV
+        cat release.env >> $GITHUB_ENV
       shell: bash
       # Use environment variables set above to create a directory. This needs
       # to be a separate step because they are not in the context yet when
@@ -340,7 +340,7 @@ jobs:
           release
     - name: Update the env variables
       run: >
-        cat release/release.env >> $GITHUB_ENV
+        cat release.env >> $GITHUB_ENV
     - name: Publish release
       run: gh release edit ${{ env.TAG_NAME }} --draft=false
       env:

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -231,10 +231,6 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: env
-    - name: Fetch release info
-      uses: actions/download-artifact@v3
-      with:
-        name: release
     - name: Put release info into env
       run: cat commit.env >> $GITHUB_ENV
       shell: bash

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -101,24 +101,21 @@ jobs:
     - name: Fetch environment variables
       uses: actions/download-artifact@v3
       with:
-        name:
-          env
+        name: env
     - name: Set environment variables
-      run: |
-        cat commit.env >> $GITHUB_ENV
-    - name: Create release
-      uses: softprops/action-gh-release@v1
-      id: create_release
+      run: cat commit.env >> $GITHUB_ENV
+    - name: Setup gh
+      uses: wusatosi/setup-gh@v1
       with:
         token: ${{ secrets.RELEASE_TOKEN }}
-        tag_name: ${{ env.TAG_NAME }}
-        name: ${{ env.RELEASE_NAME }}
+    - name: Create release
+      run: gh release create ${{ env.TAG_NAME }} -t ${{ env.RELEASE_NAME }} -n ${{ env.body }} --draft --prerelease
+      id: create_release
+      env:
         body: |
           ${{ env.RELEASE_DESCRIPTION }}
 
           Built from ${{ env.LLVM_REPO }}@${{ env.LLVM_COMMIT }}.
-        prerelease: true
-        draft: true
     - name: Preserve release info
       run: |
         echo "TAG_NAME=${{ env.TAG_NAME }}" >> release.env
@@ -197,13 +194,13 @@ jobs:
         ref: master
     - name: Install tools
       run: ${{ matrix.config.preinstall }}
-    # Visual Studio tools require a bunch of environment variables to be set.
-    # Run vcvars64.bat and re-export the current environment to the workflow.
-    # (It'd be nice to only export the variables that *changed*, oh well).
     - name: Setup gh
       uses: wusatosi/setup-gh@v1
       with:
         token: ${{ secrets.RELEASE_TOKEN }}
+    # Visual Studio tools require a bunch of environment variables to be set.
+    # Run vcvars64.bat and re-export the current environment to the workflow.
+    # (It'd be nice to only export the variables that *changed*, oh well).
     - name: Visual Studio environment
       if: matrix.config.name == 'windows'
       shell: powershell
@@ -331,13 +328,12 @@ jobs:
     - name: Fetch release info
       uses: actions/download-artifact@v3
       with:
-        name:
-          release
+        name: release
     - name: Update the env variables
-      run: >
-        cat release.env >> $GITHUB_ENV
+      run: cat release.env >> $GITHUB_ENV
+    - name: Setup gh
+      uses: wusatosi/setup-gh@v1
+      with:
+        token: ${{ secrets.RELEASE_TOKEN }}
     - name: Publish release
       run: gh release edit ${{ env.TAG_NAME }} --draft=false
-      env:
-        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        GH_REPO: ${{ github.repository }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -109,7 +109,7 @@ jobs:
       with:
         token: ${{ secrets.RELEASE_TOKEN }}
     - name: Create release
-      run: gh release create ${{ env.TAG_NAME }} -t ${{ env.RELEASE_NAME }} -n ${{ env.body }} --draft --prerelease
+      run: gh release create ${{ env.TAG_NAME }} -t "${{ env.RELEASE_NAME }}" -n "${{ env.body }}" --draft --prerelease
       env:
         body: |
           ${{ env.RELEASE_DESCRIPTION }}

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -110,7 +110,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       id: create_release
       with:
-        repository: ${{ github.repository }}
+        token: ${{ secrets.RELEASE_TOKEN }}
         tag_name: ${{ env.TAG_NAME }}
         name: ${{ env.RELEASE_NAME }}
         body: |

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -37,7 +37,7 @@ jobs:
       run: |
         sudo apt-get install jq
     - name: Clone scripts
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     # Choose the commit to build a release from.
     #
     # We want to avoid unbuildable revisions: choose the last green from CI.
@@ -68,7 +68,7 @@ jobs:
       run: >
         echo "RELEASE_DESCRIPTION=Unstable snapshot of clangd on ${{ env.RELEASE_DATE }}." >> commit.env
     - name: Upload result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: env
         path: commit.env
@@ -85,7 +85,7 @@ jobs:
         echo "RELEASE_NAME=${{ github.event.inputs.release_name }}" >> commit.env
         echo "RELEASE_DESCRIPTION=${{ github.event.inputs.description }}" >> commit.env
     - name: Upload result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: env
         path: commit.env
@@ -99,7 +99,7 @@ jobs:
     if: always() && (needs.schedule_environment.result == 'success' || needs.workflow_dispatch_environment.result == 'success')
     steps:
     - name: Fetch environment variables
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name:
           env
@@ -126,7 +126,7 @@ jobs:
         echo "TAG_NAME=${{ env.TAG_NAME }}" >> release.env
         echo "RELEASE_ID=${{ steps.create_release.outputs.id }}" >> release.env
     - name: Upload result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release
         path: release.env
@@ -196,8 +196,9 @@ jobs:
     container: ${{ matrix.config.container }}
     steps:
     - name: Clone scripts
-      uses: actions/checkout@v2
-      with: { ref: master }
+      uses: actions/checkout@v3
+      with: 
+        ref: master
     - name: Install tools
       run: ${{ matrix.config.preinstall }}
     # Visual Studio tools require a bunch of environment variables to be set.
@@ -214,7 +215,7 @@ jobs:
           }
         }
     - name: Clone gRPC
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: grpc/grpc
         path: grpc
@@ -239,15 +240,13 @@ jobs:
 
         ninja -C grpc-build install
     - name: Fetch target commit
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
-        name:
-          env
+        name: env
     - name: Fetch release info
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
-        name:
-          release
+        name: release
     - name: Put release info into env
       run: |
         cat env/commit.env >> $GITHUB_ENV
@@ -261,7 +260,7 @@ jobs:
         echo "CLANGD_DIR=clangd_${{ env.TAG_NAME }}" >> $GITHUB_ENV
       shell: bash
     - name: Clone LLVM
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ env.LLVM_REPO }}
         path: llvm-project
@@ -337,7 +336,7 @@ jobs:
     if: always() && needs.build.result == 'success'
     steps:
     - name: Fetch release info
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name:
           release

--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -203,7 +203,7 @@ jobs:
     # Run vcvars64.bat and re-export the current environment to the workflow.
     # (It'd be nice to only export the variables that *changed*, oh well).
     - name: Setup gh
-      uses: wusatosi/setup-gh@main
+      uses: wusatosi/setup-gh@v1
       with:
         token: ${{ secrets.RELEASE_TOKEN }}
     - name: Visual Studio environment


### PR DESCRIPTION
This PR updates the auto-build CI pipeline.
Specifically:
1. Updates actions/checkout
2. Updates `actions/upload-artifact`, `actions/download-artifact` and resolves the breaking change.
3. Replaces discontinued `actions/create-release` and `actions/upload-release-asset` with the GitHub CLI

Successful test on latest commit:
https://github.com/wusatosi/clangd/actions/runs/4874186461

Generated release:
https://github.com/wusatosi/clangd/releases/tag/ci-test-12

Edit: Please review @kadircet @usx95 @sam-mccall 