### PR TITLE
Strip binary after build

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -295,6 +295,9 @@ jobs:
       run: >
         cp ${{ env.CLANGD_DIR }}/projects/openmp/runtime/src/omp{,-tools}.h ${{ env.CLANGD_DIR }}/lib/clang/*/include
         || true # Don't let the non-existing omp headers block the release.
+    - name: Strip clangd
+      run: >
+        strip --strip-all ${{ env.CLANGD_DIR }}/bin/clangd${{ matrix.config.binary_extension }}
     - name: Archive clangd
       run: >
         7z a clangd.zip


### PR DESCRIPTION
I wanted to ask before making the change, but it's so easy that why not :)

Is there any good reason for not striping the binaries? This saves up to 70MiB per release file, and compressed could be even more. Not a big deal, but a nice to have, on my opinion.


Binary size
```
-rwxr-xr-x 1 ivizzo dialout 112M Sep  8 16:06 clangd-not-stripped
-rwxr-xr-x 1 ivizzo dialout  50M Sep  8 15:59 clangd
```

zip size
```
-rw-r--r-- 1 ivizzo dialout  73M Sep  8 16:09 clangd-not-stripped.zip
-rw-r--r-- 1 ivizzo dialout  19M Sep  8 16:06 clangd.zip
```