### PR TITLE
Fix runtime linkage on windows

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -151,7 +151,7 @@ jobs:
             "-DCMAKE_C_COMPILER=cl"
             "-DCMAKE_CXX_COMPILER=cl"
             "-DLLVM_ENABLE_ZLIB=OFF"
-            "-DLLVM_USE_CRT_RELEASE=MT"
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded"
           grpc_cmake: >-
             "-DgRPC_MSVC_STATIC_RUNTIME=ON"
           binary_extension: ".exe"


### PR DESCRIPTION
Because in https://github.com/llvm/llvm-project/pull/66850 the deprecated `LLVM_USE_CRT_*` was removed the weekly build failed with the observed linking issues. 

This PR attempts to fix that by using CMake's `CMAKE_MSVC_RUNTIME_LIBRARY`.