### PR TITLE
Install clangd before archiving

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -290,6 +290,12 @@ jobs:
       run: >
         ninja -C ${{ env.CLANGD_DIR }} clangd clangd-indexer clangd-index-server
         clangd-index-server-monitor
+    # Install targets so that RUNPATHs get properly substituted.
+    # FIXME: We don't have other targets besides clangd. We probably want them too.
+    - name: Install
+      run: >
+        cmake --install ${{ env.CLANGD_DIR }} --prefix ${{ env.CLANGD_DIR }}
+        "--component=clangd"
     - name: Install OpenMP headers
       shell: bash
       run: >


### PR DESCRIPTION
CMake takes additional steps beyond copying files at the installation stage. For example, it could perform the RUNPATH substitution on these trailing colons that have been produced at the build stage.

Fixes https://github.com/clangd/clangd/issues/1997