### PR TITLE
Fix Weekly snapshot releases

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -5,6 +5,8 @@
 # Because the build takes more than an hour, our GITHUB_TOKEN credentials may
 # expire. A token `secrets.RELEASE_TOKEN` must exist with public_repo scope.
 name: Build release binaries
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 on:
   # Run weekly on sunday at 21:37 UTC (arbitrary)
   schedule:
@@ -156,7 +158,7 @@ jobs:
             "-DgRPC_MSVC_STATIC_RUNTIME=ON"
           binary_extension: ".exe"
         - name: mac
-          os: macos-latest
+          os: macos-12
           preinstall: brew install ninja zlib p7zip
           cflags: -O3 -gline-tables-only -DNDEBUG
           cmake: >-
@@ -179,7 +181,7 @@ jobs:
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - &&
             apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' &&
             apt-get update &&
-            apt-get install -y git cmake
+            apt-get install -y git cmake python3.8 python3.8-dev
           cflags: -O3 -gline-tables-only -DNDEBUG -include $GITHUB_WORKSPACE/.github/workflows/lib_compat.h
           cmake: >-
             "-DCMAKE_C_COMPILER=clang-9"


### PR DESCRIPTION
This #2028 is because the macos-latest image was upgraded from macos-12 to macos-14, resulting in AppleClang being updated from version 14 to 15. To resolve the problem, simply modify macos-latest back to macos-12.

Additionally, the Linux build now requires Python 3.8 and the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION environment variable enabled. I have also addressed these issues.

I forked one and fixed compilation issues on both macOS and Linux platforms. Now GitHub Actions are working fine.