### PR TITLE
Bump upload-artifact and download-artifact version to v3

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -70,7 +70,7 @@ jobs:
       run: >
         echo "RELEASE_DESCRIPTION=Unstable snapshot of clangd on ${{ env.RELEASE_DATE }}." >> commit.env
     - name: Upload result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: env
         path: commit.env
@@ -87,7 +87,7 @@ jobs:
         echo "RELEASE_NAME=${{ github.event.inputs.release_name }}" >> commit.env
         echo "RELEASE_DESCRIPTION=${{ github.event.inputs.description }}" >> commit.env
     - name: Upload result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: env
         path: commit.env
@@ -101,9 +101,11 @@ jobs:
     if: always() && (needs.schedule_environment.result == 'success' || needs.workflow_dispatch_environment.result == 'success')
     steps:
     - name: Fetch environment variables
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name:
+          env
+        path:
           env
     - name: Set environment variables
       run: |
@@ -128,7 +130,7 @@ jobs:
         echo "TAG_NAME=${{ env.TAG_NAME }}" >> release.env
         echo "RELEASE_ID=${{ steps.create_release.outputs.id }}" >> release.env
     - name: Upload result
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: release
         path: release.env
@@ -241,14 +243,18 @@ jobs:
 
         ninja -C grpc-build install
     - name: Fetch target commit
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name:
           env
+        path:
+          env
     - name: Fetch release info
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name:
+          release
+        path:
           release
     - name: Put release info into env
       run: |
@@ -339,9 +345,11 @@ jobs:
     if: always() && needs.build.result == 'success'
     steps:
     - name: Fetch release info
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name:
+          release
+        path:
           release
     - name: Update the env variables
       run: >


### PR DESCRIPTION
The failure error for Action [#291](https://github.com/clangd/clangd/actions/runs/10763325232) indicates that GitHub has completely deprecated the v1 and v2 versions of `upload-artifact` and `download-artifact`.
This pull request bumps their versions to v3 to workaround failures.