### PR TITLE
Use macos-13 image for Mac builds

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -162,7 +162,7 @@ jobs:
             "-DgRPC_MSVC_STATIC_RUNTIME=ON"
           binary_extension: ".exe"
         - name: mac
-          os: macos-12
+          os: macos-13
           preinstall: brew install ninja zlib p7zip
           cflags: -O3 -gline-tables-only -DNDEBUG
           cmake: >-


### PR DESCRIPTION
The macos-12 image has been removed in https://github.com/actions/runner-images/issues/10721.

Fixes https://github.com/clangd/clangd/issues/2245