### PR TITLE
Fix MacOS CI builds

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -170,7 +170,7 @@ jobs:
             "-DCMAKE_CXX_COMPILER=clang++"
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
             "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
-            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
           # BoringSSL doesn't support universal binaries when building with ASM.
           grpc_cmake: >-
             "-DOPENSSL_NO_ASM=ON"


### PR DESCRIPTION
It seems the MacOS CI build has failed for 2 weeks

The error output is 
```
FAILED: tools/clang/lib/Tooling/DependencyScanning/CMakeFiles/obj.clangDependencyScanning.dir/DependencyScanningService.cpp.o 
/usr/bin/clang++ -DCLANG_EXPORTS -DGTEST_HAS_RTTI=0 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/Users/runner/work/clangd/clangd/clangd_snapshot_20250330/tools/clang/lib/Tooling/DependencyScanning -I/Users/runner/work/clangd/clangd/llvm-project/clang/lib/Tooling/DependencyScanning -I/Users/runner/work/clangd/clangd/llvm-project/clang/include -I/Users/runner/work/clangd/clangd/clangd_snapshot_20250330/tools/clang/include -I/Users/runner/work/clangd/clangd/clangd_snapshot_20250330/include -I/Users/runner/work/clangd/clangd/llvm-project/llvm/include -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -fno-common -Woverloaded-virtual -Wno-nested-anon-types -O3 -gline-tables-only -DNDEBUG -std=c++17 -arch x86_64 -arch arm64 -isysroot /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk -mmacosx-version-min=10.9  -fno-exceptions -funwind-tables -fno-rtti -MD -MT tools/clang/lib/Tooling/DependencyScanning/CMakeFiles/obj.clangDependencyScanning.dir/DependencyScanningService.cpp.o -MF tools/clang/lib/Tooling/DependencyScanning/CMakeFiles/obj.clangDependencyScanning.dir/DependencyScanningService.cpp.o.d -o tools/clang/lib/Tooling/DependencyScanning/CMakeFiles/obj.clangDependencyScanning.dir/DependencyScanningService.cpp.o -c /Users/runner/work/clangd/clangd/llvm-project/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
In file included from /Users/runner/work/clangd/clangd/llvm-project/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp:9:
In file included from /Users/runner/work/clangd/clangd/llvm-project/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h:13:
/Users/runner/work/clangd/clangd/llvm-project/clang/include/clang/Tooling/DependencyScanning/InProcessModuleCache.h:23:40: error: 'shared_mutex' is unavailable: introduced in macOS 10.12
  llvm::StringMap<std::unique_ptr<std::shared_mutex>> Map;
                                       ^
/Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/shared_mutex:181:58: note: 'shared_mutex' has been explicitly marked unavailable here
class _LIBCPP_TYPE_VIS _LIBCPP_AVAILABILITY_SHARED_MUTEX shared_mutex
                                                         ^
1 error generated.
```

This seems to be due to the code using an API `shared_mutex` , it was introduced since macOS 10.12, but I noticed that `CMAKE_OSX_DEPLOYMENT_TARGET ` was set to `10.9`. I resolved this by changing `CMAKE_OSX_DEPLOYMENT_TARGET ` to `10.13`, which make the build to complete successfully.