### PR TITLE
Windows 2019 deprecated on GitHub Actions, replace with Windows 2022

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -147,9 +147,9 @@ jobs:
       matrix:
         config:
         - name: windows
-          os: windows-2019
+          os: windows-2022
           preinstall: choco install ninja nasm
-          vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           cflags: /O2 /DNDEBUG
           cmake: >-
             "-DCMAKE_C_COMPILER=cl"


### PR DESCRIPTION
see actions/runner-images#12045
related to Actions failure https://github.com/clangd/clangd/actions/runs/16103472099