### PR TITLE
Fix Windows CI builds.

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -147,9 +147,9 @@ jobs:
       matrix:
         config:
         - name: windows
-          os: windows-2019
+          os: windows-2022
           preinstall: choco install ninja nasm
-          vcvars: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+          vcvars: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
           cflags: /O2 /DNDEBUG
           cmake: >-
             "-DCMAKE_C_COMPILER=cl"


### PR DESCRIPTION
Fix https://github.com/clangd/clangd/issues/2439. It seems that upgrading Windows' Actions runner version from Windows-2019 to Windows-2022 in the Windows CI configuration could resolve the compilation errors.