### PR TITLE
[CI] Rename debug symbol names to avoid name confusing

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -341,7 +341,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:
         upload_url: ${{ env.UPLOAD_URL }}
-        asset_name: clangd-${{ matrix.config.name }}-${{ env.TAG_NAME }}-debug-symbols.7z
+        asset_name: clangd-debug-symbols-${{ matrix.config.name }}-${{ env.TAG_NAME }}.7z
         asset_path: clangd-pdb.7z
         asset_content_type: application/zip
     - name: Upload indexing-tools asset


### PR DESCRIPTION
It seems that clients are checking filename prefixes for updating, and having two archives with the same prefix did confuse the clients.

Fixes https://github.com/clangd/node-clangd/issues/39

