### PR TITLE
Add winget publisher workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,58 @@
+name: Publish on Windows Package Manager
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Release tag (version)
+        required: true
+
+jobs:
+  publish-winget:
+    name: Publish
+    runs-on: windows-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' && !github.event.release.prerelease
+    steps:
+      - name: Configure parameters
+        id: params
+        run: |
+          if ("${{ github.event_name }}" -eq "release") {
+            echo "assets_url=${{ github.event.release.assets_url }}" >> $env:GITHUB_OUTPUT
+            echo "version=${{ github.event.release.tag_name }}" >> $env:GITHUB_OUTPUT
+          } else {
+            $releaseUrl = "$env:GITHUB_API_URL/repos/clangd/clangd/releases/tags/${{ github.event.inputs.tag_name }}"
+            $assetsUrl = curl -sL $releaseUrl | ConvertFrom-Json | Select-Object -ExpandProperty assets_url
+            echo "assets_url=$assetsUrl" >> $env:GITHUB_OUTPUT
+            echo "version=${{ github.event.inputs.tag_name }}" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Set up Komac
+        run: |
+          $releaseUrl = "$env:GITHUB_API_URL/repos/russellbanks/Komac/releases/latest"
+          $downloadUrl = curl -sL $releaseUrl | ConvertFrom-Json
+            | Select-Object -ExpandProperty assets
+            | Where-Object -Property name -like "komac-*-x86_64-pc-windows-msvc.exe"
+            | Select-Object -ExpandProperty browser_download_url
+            | Select-Object -First 1
+          curl -sL $downloadUrl -o komac.exe
+          ./komac --version
+
+      - name: Submit package
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          $releaseUrl = curl -sL ${{ steps.params.outputs.assets_url }} | ConvertFrom-Json
+            | Where-Object -Property name -like "clangd-windows-*.zip"
+            | Select-Object -ExpandProperty browser_download_url
+          $version = "${{ steps.params.outputs.version }}"
+          $installerPath = "winget-pkgs/manifests/l/LLVM/clangd/$version/LLVM.clangd.installer.yaml"
+          
+          ./komac sync-fork
+          ./komac update -v $version -u $releaseUrl --dry-run -o winget-pkgs LLVM.clangd
+          
+          (Get-Content $installerPath) -replace '^(\s*-\s+RelativeFilePath:\s+).*$', ('${1}' + "clang_$version/bin/clangd.exe")
+            | Set-Content $installerPath
+          
+          ./komac submit -y winget-pkgs

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -46,13 +46,6 @@ jobs:
           $releaseUrl = curl -sL ${{ steps.params.outputs.assets_url }} | ConvertFrom-Json
             | Where-Object -Property name -like "clangd-windows-*.zip"
             | Select-Object -ExpandProperty browser_download_url
-          $version = "${{ steps.params.outputs.version }}"
-          $installerPath = "winget-pkgs/manifests/l/LLVM/clangd/$version/LLVM.clangd.installer.yaml"
           
           ./komac sync-fork
-          ./komac update -v $version -u $releaseUrl --dry-run -o winget-pkgs LLVM.clangd
-          
-          (Get-Content $installerPath) -replace '^(\s*-\s+RelativeFilePath:\s+).*$', ('${1}' + "clangd_$version/bin/clangd.exe")
-            | Set-Content $installerPath
-          
-          ./komac submit -y winget-pkgs
+          ./komac update -v ${{ steps.params.outputs.version }} -u $releaseUrl -s LLVM.clangd

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -52,7 +52,7 @@ jobs:
           ./komac sync-fork
           ./komac update -v $version -u $releaseUrl --dry-run -o winget-pkgs LLVM.clangd
           
-          (Get-Content $installerPath) -replace '^(\s*-\s+RelativeFilePath:\s+).*$', ('${1}' + "clang_$version/bin/clangd.exe")
+          (Get-Content $installerPath) -replace '^(\s*-\s+RelativeFilePath:\s+).*$', ('${1}' + "clangd_$version/bin/clangd.exe")
             | Set-Content $installerPath
           
           ./komac submit -y winget-pkgs

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -2,7 +2,7 @@ name: Publish on Windows Package Manager
 
 on:
   release:
-    types: [published]
+    types: [released]
   workflow_dispatch:
     inputs:
       tag_name:
@@ -13,7 +13,6 @@ jobs:
   publish-winget:
     name: Publish
     runs-on: windows-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' && !github.event.release.prerelease
     steps:
       - name: Configure parameters
         id: params

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -19,11 +19,15 @@ jobs:
         id: params
         run: |
           if ("${{ github.event_name }}" -eq "release") {
+            # Sometimes assets aren't immediately available, so we wait a bit for the first run
+            ${{ github.run_attempt == 1 && 'Start-Sleep -Seconds 300' || '' }}
+            
             echo "assets_url=${{ github.event.release.assets_url }}" >> $env:GITHUB_OUTPUT
             echo "version=${{ github.event.release.tag_name }}" >> $env:GITHUB_OUTPUT
           } else {
             $releaseUrl = "$env:GITHUB_API_URL/repos/clangd/clangd/releases/tags/${{ github.event.inputs.tag_name }}"
             $assetsUrl = curl -sL $releaseUrl | ConvertFrom-Json | Select-Object -ExpandProperty assets_url
+            
             echo "assets_url=$assetsUrl" >> $env:GITHUB_OUTPUT
             echo "version=${{ github.event.inputs.tag_name }}" >> $env:GITHUB_OUTPUT
           }

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -52,4 +52,4 @@ jobs:
             | Select-Object -ExpandProperty browser_download_url
           
           ./komac sync-fork
-          ./komac update -v ${{ steps.params.outputs.version }} -u $releaseUrl -s LLVM.clangd
+          ./komac update LLVM.clangd -v ${{ steps.params.outputs.version }} -u $releaseUrl -s


### PR DESCRIPTION
Fixes #2436 

This PR adds a GitHub Actions workflow to publish clangd on Windows Package Manager (winget) either manually or automatically when a new release is published on GitHub Releases.

The following configuration is required to make it work:

- Configure a _classic_ GitHub personal access token (PAT) for a specific user account. For instance, @clangd-build 
- Configure the above token as a repo secret named `WINGET_TOKEN` (or any other name, but that requires updating the workflow)
- Fork [winget-pkgs](https://github.com/microsoft/winget-pkgs) repo under the above account
