### PR TITLE
Fix issue #2521

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -171,6 +171,7 @@ jobs:
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
             "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
             "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
           # BoringSSL doesn't support universal binaries when building with ASM.
           grpc_cmake: >-
             "-DOPENSSL_NO_ASM=ON"


### PR DESCRIPTION
Added "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" for MacOS CI build to workaround the issue #2521 
Tested at my actions: https://github.com/InfinityWei/clangd/actions/workflows/autobuild.yaml