### PR TITLE
Updating grpc verion to 1.71.0

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -228,7 +228,7 @@ jobs:
         # We use the same version of gRPC for LLVM's clangd-ubuntu-tsan
         # buildbot.
         # https://github.com/llvm/llvm-zorg/blob/main/buildbot/google/docker/buildbot-clangd-ubuntu-clang/Dockerfile
-        ref: v1.36.3
+        ref: v1.71.0
         submodules: recursive
     - name: Build gRPC
       run: >


### PR DESCRIPTION
gRPC is on an older version; we tried to use a TLS-enabled connection, which requires the latest version of gRPC.