### PR TITLE
Update MacOS image's version and upgrade MacOS‘s grpc only to fix compilation error

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -158,11 +158,12 @@ jobs:
             "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded"
             "-DLLVM_ENABLE_PDB=ON"
             "-DLLVM_PARALLEL_LINK_JOBS=1"
+          grpc_version: v1.36.3
           grpc_cmake: >-
             "-DgRPC_MSVC_STATIC_RUNTIME=ON"
           binary_extension: ".exe"
         - name: mac
-          os: macos-13
+          os: macos-14
           preinstall: brew install ninja zlib p7zip
           cflags: -O3 -gline-tables-only -DNDEBUG
           cmake: >-
@@ -172,6 +173,8 @@ jobs:
             "-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64"
             "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13"
             "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+            "-Dabsl_DIR=$HOME/grpc-installation/lib/cmake/absl"
+          grpc_version: v1.51.3
           # BoringSSL doesn't support universal binaries when building with ASM.
           grpc_cmake: >-
             "-DOPENSSL_NO_ASM=ON"
@@ -195,6 +198,7 @@ jobs:
             "-DLLVM_STATIC_LINK_CXX_STDLIB=ON"
             "-DLLVM_ENABLE_ZLIB=FORCE_ON"
             "-DCMAKE_PROJECT_INCLUDE=$GITHUB_WORKSPACE/.github/workflows/linux-static-deps.cmake"
+          grpc_version: v1.36.3
           # Using c-ares as a module prevents dynamic linking of unneeded
           # libraries. All other gRPC dependencies can be built from sources.
           grpc_cmake: >-
@@ -228,7 +232,7 @@ jobs:
         # We use the same version of gRPC for LLVM's clangd-ubuntu-tsan
         # buildbot.
         # https://github.com/llvm/llvm-zorg/blob/main/buildbot/google/docker/buildbot-clangd-ubuntu-clang/Dockerfile
-        ref: v1.36.3
+        ref: ${{ matrix.config.grpc_version }} 
         submodules: recursive
     - name: Build gRPC
       run: >


### PR DESCRIPTION
Due to https://github.com/actions/runner-images/issues/13046, we have to bump the image version to macos-14
However, it will cause compilation error because the old gRPC version does not support Apple Silicon aarch64 machines.
So we have to bump the gRPC version to v1.51.3 only for MacOS.
Fixes https://github.com/clangd/clangd/issues/2562