### PR TITLE
Remove ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION

### DIFF
--- a/.github/workflows/autobuild.yaml
+++ b/.github/workflows/autobuild.yaml
@@ -5,8 +5,6 @@
 # Because the build takes more than an hour, our GITHUB_TOKEN credentials may
 # expire. A token `secrets.RELEASE_TOKEN` must exist with public_repo scope.
 name: Build release binaries
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 on:
   # Run weekly on sunday at 21:37 UTC (arbitrary)
   schedule:


### PR DESCRIPTION
This has the effect of changing the node version used to run
the action from node 20 to node 24.